### PR TITLE
Enable audio playback while navigating diff pages

### DIFF
--- a/src/Layout/_app.js
+++ b/src/Layout/_app.js
@@ -1,13 +1,28 @@
-import React from 'react';
+import React from "react";
 import "@/styles/globals.css";
-import Layout from './Layout'; 
+import Layout from "./Layout";
+import { AudioContext, AudioProvider } from "@/context/AudioContext";
 
 function MyApp({ Component, pageProps }) {
   return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
+    <AudioProvider>
+      <PersistentAudioPlayer />
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </AudioProvider>
   );
 }
+
+const PersistentAudioPlayer = () => {
+  const { audioRef } = React.useContext(AudioContext);
+
+  return (
+    <audio ref={audioRef} style={{ display: 'none' }}>
+      <source src="https://swahilipotfm.out.airtime.pro/swahilipotfm_a?_ga=2.140975346.1118176404.1720613685-1678527295.1702105127" type="audio/mpeg" />
+      Your browser does not support the audio element.
+    </audio>
+  );
+};
 
 export default MyApp;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,11 +1,11 @@
 /* eslint-disable @next/next/no-img-element */
-import React, { useRef, useState, useEffect, useContext } from 'react'
-import Link from 'next/link'
-import style from '../styles/Header.module.css'
-import { AudioContext } from '../context/AudioContext'
+import React, { useRef, useState, useEffect, useContext } from "react";
+import Link from "next/link";
+import style from "../styles/Header.module.css";
+import { AudioContext } from "../context/AudioContext";
 
 const Header = () => {
-  const { isPlaying, togglePlay } = useContext(AudioContext)
+  const { isPlaying, togglePlay } = useContext(AudioContext);
 
   return (
     <>
@@ -13,155 +13,108 @@ const Header = () => {
         className={`navbar navbar-expand-lg navbar-light ${style.header}`}
       >
         <div className={`container ${style.container}`}>
-          <Link href='/' legacyBehavior>
-            <a className='navbar-brand' aria-label='Space'>
+          <Link href="/" legacyBehavior>
+            <a className="navbar-brand" aria-label="Space">
               <img
-                className={`navbar-brand-logo ${style['brand-logo']}`}
-                src='/branding/logo-no-bg-1080.png'
-                alt='Image Description'
+                className={`navbar-brand-logo ${style["brand-logo"]}`}
+                src="/branding/logo-no-bg-1080.png"
+                alt="Image Description"
               />
             </a>
           </Link>
-          <div
-            className={`d-block d-lg-none ${style['livestream-mobile']}`}
-          >
-            <Link href='/live' legacyBehavior>
-              <a 
-                className={`btn ${style['listen-live-btn']}`}
-                onClick={togglePlay}
+          <div className={`d-block d-lg-none ${style["livestream-mobile"]}`}>
+            <Link href="/live" legacyBehavior>
+              <a
+                className={`btn ${style["listen-live-btn"]}`}
+                onClick={(e) => {
+                  e.preventDefault();
+                  togglePlay();
+                }}
               >
-                {isPlaying ? 'Pause' : 'Listen Live'}
+                {isPlaying ? "Pause" : "Listen Live"}
               </a>
             </Link>
           </div>
           <button
-            className='navbar-toggler'
-            type='button'
-            data-bs-toggle='collapse'
-            data-bs-target='#navbarNavDropdown'
-            aria-controls='navbarNavDropdown'
-            aria-expanded='false'
-            aria-label='Toggle navigation'
+            className="navbar-toggler"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#navbarNavDropdown"
+            aria-controls="navbarNavDropdown"
+            aria-expanded="false"
+            aria-label="Toggle navigation"
           >
-            <span className='navbar-toggler-icon'></span>
+            <span className="navbar-toggler-icon"></span>
           </button>
-          <div
-            className='collapse navbar-collapse'
-            id='navbarNavDropdown'
-          >
-            <ul className='navbar-nav ms-auto'>
-              <li
-                className={`nav-item ${style['nav-item']}`}
-              >
-                <Link href='/' legacyBehavior>
-                  <a
-                    className={`nav-link ${style['nav-link']}`}
-                  >
+          <div className="collapse navbar-collapse" id="navbarNavDropdown">
+            <ul className="navbar-nav ms-auto">
+              <li className={`nav-item ${style["nav-item"]}`}>
+                <Link href="/" legacyBehavior>
+                  <a className={`nav-link ${style["nav-link"]}`}>
                     Home
-                    <span
-                      className={style['music-bars']}
-                    ></span>
+                    <span className={style["music-bars"]}></span>
                   </a>
                 </Link>
               </li>
-              <li
-                className={`nav-item ${style['nav-item']}`}
-              >
-                
-              </li>
-              <li
-                className={`nav-item ${style['nav-item']}`}
-              >
-                <Link href='/media' legacyBehavior>
-                  <a
-                    className={`nav-link ${style['nav-link']}`}
-                  >
+              <li className={`nav-item ${style["nav-item"]}`}></li>
+              <li className={`nav-item ${style["nav-item"]}`}>
+                <Link href="/media" legacyBehavior>
+                  <a className={`nav-link ${style["nav-link"]}`}>
                     Media
-                    <span
-                      className={style['music-bars']}
-                    ></span>
+                    <span className={style["music-bars"]}></span>
                   </a>
                 </Link>
               </li>
-              <li
-                className={`nav-item ${style['nav-item']}`}
-              >
-                <Link href='/news' legacyBehavior>
-                  <a
-                    className={`nav-link ${style['nav-link']}`}
-                  >
+              <li className={`nav-item ${style["nav-item"]}`}>
+                <Link href="/news" legacyBehavior>
+                  <a className={`nav-link ${style["nav-link"]}`}>
                     News
-                    <span
-                      className={style['music-bars']}
-                    ></span>
+                    <span className={style["music-bars"]}></span>
                   </a>
                 </Link>
               </li>
-              <li
-                className={`nav-item ${style['nav-item']}`}
-              >
-                <Link href='/programs' legacyBehavior>
-                  <a
-                    className={`nav-link ${style['nav-link']}`}
-                  >
+              <li className={`nav-item ${style["nav-item"]}`}>
+                <Link href="/programs" legacyBehavior>
+                  <a className={`nav-link ${style["nav-link"]}`}>
                     Programs
-                    <span
-                      className={style['music-bars']}
-                    ></span>
+                    <span className={style["music-bars"]}></span>
                   </a>
                 </Link>
               </li>
-              <li
-                className={`nav-item ${style['nav-item']}`}
-              >
-                <Link href='/schedule' legacyBehavior>
-                  <a
-                    className={`nav-link ${style['nav-link']}`}
-                  >
+              <li className={`nav-item ${style["nav-item"]}`}>
+                <Link href="/schedule" legacyBehavior>
+                  <a className={`nav-link ${style["nav-link"]}`}>
                     Schedule
-                    <span
-                      className={style['music-bars']}
-                    ></span>
+                    <span className={style["music-bars"]}></span>
                   </a>
                 </Link>
               </li>
-              <li
-                className={`nav-item ${style['nav-item']}`}
-              >
-                <Link href='/about' legacyBehavior>
-                  <a
-                    className={`nav-link ${style['nav-link']}`}
-                  >
+              <li className={`nav-item ${style["nav-item"]}`}>
+                <Link href="/about" legacyBehavior>
+                  <a className={`nav-link ${style["nav-link"]}`}>
                     About
-                    <span
-                      className={style['music-bars']}
-                    ></span>
+                    <span className={style["music-bars"]}></span>
                   </a>
                 </Link>
               </li>
-              <li
-                className={`nav-item ${style['nav-item']}`}
-              >
-                <Link href='/#youth-database-section' legacyBehavior>
-                  <a
-                    className={`nav-link ${style['nav-link']}`}
-                  >
+              <li className={`nav-item ${style["nav-item"]}`}>
+                <Link href="/#youth-database-section" legacyBehavior>
+                  <a className={`nav-link ${style["nav-link"]}`}>
                     Join Us
-                    <span
-                      className={style['music-bars']}
-                    ></span>
+                    <span className={style["music-bars"]}></span>
                   </a>
                 </Link>
-              </li> 
-              <li
-                className={`nav-item d-none d-lg-block ${style['nav-item']}`}
-              >
-                <Link href='/live' legacyBehavior>
-                  <a 
-                    className={`btn ${style['listen-live-btn']}`}
-                    onClick={togglePlay}
+              </li>
+              <li className={`nav-item d-none d-lg-block ${style["nav-item"]}`}>
+                <Link href="/live" legacyBehavior>
+                  <a
+                    className={`btn ${style["listen-live-btn"]}`}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      togglePlay();
+                    }}
                   >
-                    {isPlaying ? 'Pause' : 'Listen Live'}
+                    {isPlaying ? "Pause" : "Listen Live"}
                   </a>
                 </Link>
               </li>
@@ -170,7 +123,7 @@ const Header = () => {
         </div>
       </header>
     </>
-  )
-}
+  );
+};
 
-export default Header
+export default Header;

--- a/src/context/AudioContext.js
+++ b/src/context/AudioContext.js
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useRef } from 'react';
+import React, { createContext, useState, useRef, useEffect } from "react";
 
 export const AudioContext = createContext();
 
@@ -6,20 +6,39 @@ export const AudioProvider = ({ children }) => {
   const [isPlaying, setIsPlaying] = useState(false);
   const audioRef = useRef(null);
 
-  const togglePlay = () => {
-    if (audioRef.current) {
-      if (isPlaying) {
-        audioRef.current.pause();
-      } else {
-        audioRef.current.play();
-      }
-      setIsPlaying(!isPlaying);
+  useEffect(() => {
+    if (!audioRef.current) {
+      audioRef.current = new Audio(
+        "https://swahilipotfm.out.airtime.pro/swahilipotfm_a?_ga=2.140975346.1118176404.1720613685-1678527295.1702105127"
+      );
+      audioRef.current.loop = true;
     }
+
+    return () => {
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current = null;
+      }
+    };
+  }, []);
+
+  
+  const togglePlay = () => {
+    if (!audioRef.current) return;
+
+    if (isPlaying) {
+      audioRef.current.pause();
+    } else {
+      audioRef.current.play();
+    }
+    setIsPlaying(!isPlaying);
   };
 
   return (
-    <AudioContext.Provider value={{ isPlaying, setIsPlaying, togglePlay, audioRef }}>
+    <AudioContext.Provider
+      value={{ isPlaying, setIsPlaying, togglePlay, audioRef }}
+    >
       {children}
     </AudioContext.Provider>
   );
-}; 
+};


### PR DESCRIPTION
Enabled Audio Playback in Background While Navigating Pages

## Description
Implemented a "Listen Live" button that allows audio to play in the background as users navigate to other pages on the site. The audio should continue playing uninterrupted, regardless of page transitions.



## Type of change
Please delete options that are not relevant.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Screenshots/Images

![audioBackground](https://github.com/user-attachments/assets/cf981816-fbd5-4722-b516-424f93a7629f)
The PersistentAudioPlayer function is used to enable background play of audio while not displaying

![audioContext](https://github.com/user-attachments/assets/ea2f2fec-9b9d-438c-a2ac-a3774d875862)
use to prevent re-initialization and prepare playback with loop


## Checklist:
- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.